### PR TITLE
Wildkeys Pipeline

### DIFF
--- a/dags/wildkeys.py
+++ b/dags/wildkeys.py
@@ -1,0 +1,215 @@
+import logging
+import shutil
+from datetime import datetime
+from itertools import islice
+from pathlib import Path
+from typing import Dict, Optional
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.python import PythonOperator
+from airflow.utils.trigger_rule import TriggerRule
+
+from ideafast_etl.hooks.db import DeviceType, LocalMongoHook, Record
+from ideafast_etl.hooks.dmp import DmpHook
+from ideafast_etl.hooks.wks import WildkeysHook
+from ideafast_etl.operators.ucam import GroupRecordsOperator
+
+# DAG setup with tasks
+with DAG(
+    dag_id="wildkeys",
+    description="A complete WildKeys ETL pipeline",
+    # arbitrary start date, UNLESS USED TO RUN HISTORICALLY!
+    start_date=datetime(year=2019, month=11, day=1),
+    schedule_interval=None,
+    catchup=False,
+    render_template_as_native_obj=True,
+) as dag:
+
+    dag_run_download_folder = "/opt/airflow/downloads/{{dag.dag_id}}_{{ts_nodash}}"
+
+    def _download_metadata(limit: Optional[int] = None) -> None:
+        """
+        Retrieve records on Dreem's servers, filters only the new
+
+        Parameters
+        ----------
+        limit : None | int
+            limit of how many records to handle this run - useful for testing
+            or managing workload in batches
+        """
+        with LocalMongoHook() as db:
+
+            # get all results
+            with WildkeysHook() as wks:
+                participants = wks.get_participants()
+                records_per_participant: Dict[str, dict] = {
+                    p: wks.get_metadata(p) for p in participants
+                }
+                # records =  {partic1 : {date1 : [times], date2 : [times], ...}, partic2 : ...}
+
+            # create hashes of found records, deduct with known records
+            known = db.find_wildkeys_hashes(DeviceType.WKS)
+
+            # generator for new records and records to update (consider 'new')
+            new_record_gen = (
+                Record(
+                    _id=None,
+                    hash=hash,
+                    manufacturer_ref=manu_ref,
+                    device_type=DeviceType.WKS,
+                    start=datetime.fromtimestamp(min(timestamps)),
+                    end=datetime.fromtimestamp(max(timestamps)),
+                    meta=dict(count=len(timestamps)),
+                )
+                for p, records in records_per_participant.items()
+                for date, timestamps in records.items()
+                if (
+                    hash := Record.generate_hash(
+                        manu_ref := f"{p}-{date}", DeviceType.WKS
+                    )
+                )
+                not in known
+                or len(timestamps) != known[hash]
+            )
+
+            new_records = list(islice(new_record_gen, limit))
+            new_ids = db.custom_insert_many(new_records) if new_records else []
+
+            # Logging
+            logging.info(
+                f"{len([v for v in records_per_participant.values()])} WKS records found on the server"
+            )
+            logging.info(
+                f"{len(new_ids)} new Wildkeys records added to the DB (limit was {limit})"
+            )
+
+    def _extract_prep_load(
+        download_folder: str,
+        limit: Optional[int] = None,
+    ) -> None:
+        """
+        Download, zip, and upload records to the DMP
+
+        Unfortunately, dynamically generating task within a DAG is proven to be difficult and hacky.
+        For now, this task just sequentially handles down and upload.
+
+        Parameters
+        ----------
+        limit : None | int
+            limit of how many down and upload pairs to handle this run - useful for testing
+            or managing workload in batches
+        """
+        dmp_mappings: dict = Variable.get("dmp_dataset_mappings", deserialize_json=True)
+
+        with LocalMongoHook() as db, WildkeysHook() as wks, DmpHook() as dmp:
+            unfinished_dmp_ids = list(
+                islice(db.find_notuploaded_dmpids(DeviceType.WKS), limit)
+            )
+            finished_dmp_ids, processed_records = 0, 0
+
+            for dmp_id in unfinished_dmp_ids:
+
+                path = Path(download_folder) / dmp_id
+                path.mkdir(parents=True, exist_ok=True)
+                logging.debug(f"Created {str(path)} in local storage")
+
+                records = db.find_records_by_dmpid(dmp_id)
+                # dmp_dataset = records[0].dmp_dataset
+                dmp_dataset: str = dmp_mappings.get("TEST")
+
+                try:
+                    # DOWNLOAD
+                    total_records = len(records)
+                    for index, record in enumerate(records, start=1):
+                        wks.download_file(record.manufacturer_ref, path)
+                        logging.debug(
+                            f"Downloaded {index}/{total_records} files for {dmp_id}"
+                        )
+
+                    # ZIP
+                    zip_path = dmp.zip_folder(path)
+
+                    # UPLOAD
+                    # if any records already uploaded, perform DMP UPDATE
+                    if any([r.is_uploaded for r in records]):
+                        raise NotImplementedError
+                    else:
+                        # success = dmp.dmp_upload(dmp_dataset, zip_path)
+                        success = dmp.upload(dmp_dataset, zip_path)
+
+                    if not success:
+                        # abort updating, retry next time
+                        # Log something here...
+                        continue
+
+                    # UPDATE DB
+                    update_count = db.update_dmpid_records_uploaded(dmp_id)
+                    processed_records += update_count
+                    finished_dmp_ids += 1
+
+                except Exception as e:
+                    logging.error(
+                        f"Error in processing records with DMP ID {dmp_id}", exc_info=e
+                    )
+
+                finally:
+                    # always remove local data, regardless of the outcome
+                    dmp.rm_local_data(path.parent / f"{path.name}.zip")
+                    logging.info("Removed (intermediate) downloaded files")
+                    pass
+
+            logging.info(
+                f"retrieved {len(unfinished_dmp_ids)} folders to be uploaded with limit {limit}"
+            )
+            logging.info(f"uploaded {finished_dmp_ids} .zips to the DMP")
+            logging.info(f"finished {processed_records} records on the DB")
+
+    def _cleanup(download_folder: str) -> None:
+        """
+        Clean up any downloads into the
+
+        Unfortunately, dynamically generating task within a DAG is proven to be difficult and hacky.
+        For now, this task just sequentially handles down and upload.
+
+        Parameters
+        ----------
+        limit : None | int
+            limit of how many down and upload pairs to handle this run - useful for testing
+            or managing workload in batches
+        """
+        if Path(download_folder).is_dir():
+            shutil.rmtree(download_folder)
+        logging.info(f"Removed {download_folder} from local storage")
+
+    # Set all tasks
+    download_metadata = PythonOperator(
+        task_id="download_metadata",
+        python_callable=_download_metadata,
+        op_kwargs={"limit": 15},
+    )
+
+    group_records = GroupRecordsOperator(
+        task_id="group_records",
+        cut_off_time="12:00:00",
+        # TODO: discuss threshold with WP4 at TFTI
+        device_type=DeviceType.WKS,
+    )
+
+    extract_prep_load = PythonOperator(
+        task_id="extract_prep_load",
+        python_callable=_extract_prep_load,
+        op_kwargs={"download_folder": dag_run_download_folder, "limit": 1},
+    )
+
+    cleanup = PythonOperator(
+        task_id="cleanup",
+        python_callable=_cleanup,
+        # trigger cleanup even if upstream tasks are skipped or failed
+        trigger_rule=TriggerRule.ALL_DONE,
+        op_kwargs={"download_folder": dag_run_download_folder},
+    )
+
+    # Set linear dependencies between the static tasks
+
+    download_metadata >> group_records >> extract_prep_load >> cleanup

--- a/ideafast_etl/hooks/db.py
+++ b/ideafast_etl/hooks/db.py
@@ -25,6 +25,7 @@ class DeviceType(Enum):
     BED = 9  # EBedSensor
     VTP = 10  # Vital Patch
     YSM = 11  # ZKOne YOLI
+    WKS = 12  # FC.ID WildKeys
 
 
 @dataclass
@@ -229,3 +230,8 @@ class LocalMongoHook(MongoHook):
         """Get all hash representations of stored files"""
         result = self.__custom_find(filter={"device_type": device_type.name})
         return {r.hash for r in result}
+
+    def find_wildkeys_hashes(self) -> Dict[str, int]:
+        """Get all Wildkeys hash representations of stored files, including their sensor count"""
+        result = self.__custom_find(filter={"device_type": DeviceType.WKS})
+        return {r.hash: r.meta.get("count") for r in result}

--- a/ideafast_etl/hooks/db.py
+++ b/ideafast_etl/hooks/db.py
@@ -3,7 +3,7 @@ import warnings
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Generator, List, Optional, Set
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple
 
 from airflow.providers.mongo.hooks.mongo import MongoHook
 from bson import ObjectId
@@ -78,6 +78,17 @@ class LocalMongoHook(MongoHook):
         """Insert one record into the DB, return the ID"""
         result = self.insert_one(**DEFAULTS, doc=record.as_db_dict)
         return result.inserted_id
+
+    def custom_replace_one(self, record: Record) -> ObjectId:
+        """
+        Replace one record into the DB, returns the ID
+
+        Uses the _id in the provided `record` to find the db document
+        """
+        result = self.replace_one(
+            **DEFAULTS, doc={"_id": record._id, **record.as_db_dict}
+        )
+        return result.acknowledged
 
     def custom_insert_many(self, records: List[Record]) -> List[ObjectId]:
         """Insert multiple records into the DB, return the ID"""
@@ -231,7 +242,7 @@ class LocalMongoHook(MongoHook):
         result = self.__custom_find(filter={"device_type": device_type.name})
         return {r.hash for r in result}
 
-    def find_wildkeys_hashes(self) -> Dict[str, int]:
+    def find_wildkeys_hashes(self) -> Dict[str, Tuple[int, ObjectId]]:
         """Get all Wildkeys hash representations of stored files, including their sensor count"""
-        result = self.__custom_find(filter={"device_type": DeviceType.WKS})
-        return {r.hash: r.meta.get("count") for r in result}
+        result = self.__custom_find(filter={"device_type": DeviceType.WKS.name})
+        return {r.hash: (r.meta.get("count"), r._id) for r in result}

--- a/ideafast_etl/hooks/wks.py
+++ b/ideafast_etl/hooks/wks.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections import defaultdict
 from datetime import datetime
@@ -20,6 +21,9 @@ class WildkeysHook(JwtHook):
     date_format = "%Y%m%d"
     default_conn_name = "wks_default"
 
+    # FIXME: remove variable once live connection
+    CURRENT_DIR = Path(__file__).parent
+
     def __init__(self, conn_id: str = default_conn_name) -> None:
         """Init a JwtHook with overriden default connection name"""
         super().__init__(conn_id=conn_id)
@@ -34,11 +38,16 @@ class WildkeysHook(JwtHook):
 
         url = self.base_url + "/participants/list"
 
-        response = session.get(url)
-        response.raise_for_status()
-        result: dict = response.json()
+        # response = session.get(url)
+        # response.raise_for_status()
+        # result: dict = response.json()
+        # FIXME: use active url above when LIVE
+        with open(
+            self.CURRENT_DIR.parent / "dummy/test_wks_participants.json", "r"
+        ) as f:
+            result: dict = json.load(f)
 
-        return [k for k in result.get("participants").keys()]
+            return [k for k in result.keys()]
 
     def get_metadata(self, participant: str) -> Dict[str, list]:
         """
@@ -53,39 +62,60 @@ class WildkeysHook(JwtHook):
 
         url = self.base_url + f"/participants/{participant}/summary"
 
-        response = session.get(url)
-        response.raise_for_status()
-        result: list = response.json()
+        # response = session.get(url)
+        # response.raise_for_status()
+        # result: list = response.json()
+        # FIXME: use active url above when LIVE
+        with open(self.CURRENT_DIR.parent / "dummy/test_wks_timestamps.json", "r") as f:
+            # use line below to test that it picks up new records if more timestamps are found
+            # with open(
+            #     self.CURRENT_DIR.parent / "dummy/test_wks_timestamps_found_more.json", "r"
+            # ) as f:
+            result: dict = json.load(f)
 
-        days = defaultdict(list)
-        for timestamp in result:
-            day = datetime.fromtimestamp(timestamp).strftime(self.date_format)
-            days[day].append(timestamp)
+            days = defaultdict(list)
+            for timestamp in result:
+                in_seconds = int(timestamp / 1e3)
+                day = datetime.fromtimestamp(in_seconds).strftime(self.date_format)
+                days[day].append(in_seconds)
 
-        return days
+            return days
 
-    def download_file(self, file_ref: str, download_path: Path) -> bool:
+    def download_file(
+        self, participant_id: str, date: str, download_path: Path
+    ) -> bool:
         """Download file from Wildkeys servers"""
         session = self.get_conn()
-        participant_id, date = file_ref.split("-")
+        participant = participant_id.replace("-", "")
         url = (
             self.base_url
-            + f"participants/{participant_id}"
+            + f"participants/{participant}"
             + f"?from={self.start_of_day(date)}&to={self.end_of_day(date)}"
         )
 
-        file_path = download_path / f"{file_ref}.json"
+        file_path = download_path / f"{participant}-{date}.json"
 
-        with session.get(url, stream=True) as response:
-            response.raise_for_status()
-            total_size = int(response.headers.get("content-length"))
+        # with session.get(url, stream=True) as response:
+        # response.raise_for_status()
+        # total_size = int(response.headers.get("content-length"))
+        # FIXME: use active url above when LIVE
+        with open(
+            self.CURRENT_DIR.parent / "dummy/test_wks_download.json", "r"
+        ) as response:
+            total_size = 1065  # simulate lines as chunks
             total_down, percent_down = 0, 0
 
             with open(file_path, "wb") as output_file:
-                for chunk in response.iter_content(chunk_size=1024):
+                # for chunk in response.iter_content(chunk_size=1024):
+                # FIXME: use iter_content from response.json() once LIVE
+                for fake_chunk in response.readline():
+                    # FIXME: remove byte conversion when LIVE
+                    chunk = bytes(fake_chunk, "utf-8")
                     if chunk:
                         output_file.write(chunk)
-                        total_down += len(chunk)
+                        # total_down += len(chunk)
+                        # FIXME: use chunk length when LIVE
+                        total_down += 1
                     if (
                         chunk
                         and (status := int((total_down / total_size) * 100))

--- a/ideafast_etl/hooks/wks.py
+++ b/ideafast_etl/hooks/wks.py
@@ -1,0 +1,116 @@
+import logging
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from ideafast_etl.hooks.jwt import JwtHook
+
+
+class WildkeysHook(JwtHook):
+    """
+    Hook for interfacing with the JWT REST APIs from Wildkeys
+
+    Parameters
+    ----------
+    conn_id : str
+        ID of the connection to use to connect to the Dreem API
+    """
+
+    date_format = "%Y%m%d"
+    default_conn_name = "wks_default"
+
+    def __init__(self, conn_id: str = default_conn_name) -> None:
+        """Init a JwtHook with overriden default connection name"""
+        super().__init__(conn_id=conn_id)
+
+    def _get_jwt_token(self) -> str:
+        """FIXME: TEMPORARY OVERRIDE FOR TESTING"""
+        return "all_good"
+
+    def get_participants(self) -> List[str]:
+        """GET all participants"""
+        session = self.get_conn()
+
+        url = self.base_url + "/participants/list"
+
+        response = session.get(url)
+        response.raise_for_status()
+        result: dict = response.json()
+
+        return [k for k in result.get("participants").keys()]
+
+    def get_metadata(self, participant: str) -> Dict[str, list]:
+        """
+        GET a count of recordings per day of a participant
+
+        Parameters
+        ----------
+        participants : str
+            a participant ID to query the API for
+        """
+        session = self.get_conn()
+
+        url = self.base_url + f"/participants/{participant}/summary"
+
+        response = session.get(url)
+        response.raise_for_status()
+        result: list = response.json()
+
+        days = defaultdict(list)
+        for timestamp in result:
+            day = datetime.fromtimestamp(timestamp).strftime(self.date_format)
+            days[day].append(timestamp)
+
+        return days
+
+    def download_file(self, file_ref: str, download_path: Path) -> bool:
+        """Download file from Wildkeys servers"""
+        session = self.get_conn()
+        participant_id, date = file_ref.split("-")
+        url = (
+            self.base_url
+            + f"participants/{participant_id}"
+            + f"?from={self.start_of_day(date)}&to={self.end_of_day(date)}"
+        )
+
+        file_path = download_path / f"{file_ref}.json"
+
+        with session.get(url, stream=True) as response:
+            response.raise_for_status()
+            total_size = int(response.headers.get("content-length"))
+            total_down, percent_down = 0, 0
+
+            with open(file_path, "wb") as output_file:
+                for chunk in response.iter_content(chunk_size=1024):
+                    if chunk:
+                        output_file.write(chunk)
+                        total_down += len(chunk)
+                    if (
+                        chunk
+                        and (status := int((total_down / total_size) * 100))
+                        > percent_down + 10
+                    ):
+                        percent_down = round(status, -1)
+                        logging.info(f"{percent_down}% Downloaded")
+
+                logging.info("100% Downloaded")
+
+        return True
+
+    @classmethod
+    def start_of_day(cls, day: str) -> int:
+        """Normalise a daytime to 00:00:00 for unix timestamp"""
+        start = datetime.strptime(day, cls.date_format)
+        return int(
+            start.replace(hour=0, minute=0, second=0, microsecond=0).timestamp() * 1e3
+        )
+
+    @classmethod
+    def end_of_day(cls, day: str) -> int:
+        """Normalise a daytime to 23:59:59 for unix timestamp"""
+        end = datetime.strptime(day, cls.date_format)
+        return int(
+            end.replace(hour=23, minute=59, second=59, microsecond=999999).timestamp()
+            * 1e3
+        )

--- a/init/connections.yaml.example
+++ b/init/connections.yaml.example
@@ -49,3 +49,17 @@ dmp_default:
     }
   port: null
   schema: null
+
+wks_default:
+  conn_type: JWT
+  description: "Custom API connection with Wildkeys servers"
+  host: wks_url_api
+  login: wks_user
+  password: wks_pass
+  extra: |
+    {
+      "jwt_url": "wks_token_url",
+      "jwt_token_path": "dict.path.to.token",
+    }
+  port: null
+  schema: null

--- a/tests/hooks/test_wks.py
+++ b/tests/hooks/test_wks.py
@@ -1,0 +1,17 @@
+import requests
+
+from ideafast_etl.hooks.wks import WildkeysHook
+
+# TODO: add tests once API is set up and approach is agreed
+
+
+def test_jwt_prepared_request():
+    """Test that the prepare method returns a PREPARED request"""
+    wks_hook = WildkeysHook()
+    wks_hook.jwt_url = "http://test"
+    wks_hook.user = "test_user"
+    wks_hook.passw = "test_passw"
+
+    result = wks_hook._jwt_prepared_request()
+
+    assert isinstance(result, requests.PreparedRequest)


### PR DESCRIPTION
This (draft) PR includes the initial setup for the Wildkeys pipeline. We don't have a live API endpoint to query, so this is currently fixed at various points in this codebase to replace with local files (4 `test_wks_*.json` files in `idefast_etl/dummy` - please ask via Teams to receive these). The dummy files and overall pipeline flow are based on the draft API provided by Wildkeys. One request for an endpoint has been made to simplify the download stage, the current implementation assumes this will be implemented.

### Flow
Since the Wildkeys API includes the participant ID, and the device ID is fixed (and therefore hardcoded), the device_id and patient_id resolver tasks are omitted. In addition, due to the nature of the data collection, the records in the `mongodb` are structured _by day_. The pipeline will compare the total number of recordings for a participant _by day_, and update a record (and re-download all sensor data for that day) if a change in that number is detected. Therefore, the `group_records` tasks will always result in groups of 1. However, it does include logic for naming the DMP uploads, hence we retain this task in the pipeline.

### Todo:
- [ ] implement tests after API usage is agreed upon
- [ ] remove all `FIXME:` statements and 'revert' the temporary measures
