### PR TITLE
Add services to a docker network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ _MONGO_INITDB_ROOT_PASSWORD=mongo_password
 # Generate Fernet key by running
 # ./airflow.sh python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
 _AIRFLOW__CORE__FERNET_KEY=""
-
+_WP3API_AIRFLOW_PASS=""
 
 # --- CONNECTIONS ---
 # update connections details in init/connections.yaml

--- a/cli.py
+++ b/cli.py
@@ -23,7 +23,7 @@ def get_latest_docker_tag() -> Optional[str]:
     """Retrieve latest tag from the IDEAFAST Docker Images on you machine"""
     res = run_command(
         f"docker images {DOCKER_REGISTRY} --format {{{{.Tag}}}} "
-        f"| egrep -v 'latest' | sort -r | head -n 1",
+        f"| egrep -v 'latest|<none>' | sort -r | head -n 1",
         True,
     )
     return res.stdout.decode("ascii").rstrip() or None

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,7 @@ version: '3.5'
 networks:
   ideafastetl:
     name: ideafast-etl
+    external: true
 
 x-ideafast-etl-variables:
   &ideafast-etl-env
@@ -74,7 +75,7 @@ x-airflow-common:
     mongodb:
       condition: service_healthy
   networks:
-    - ideafastetl
+    - ideafast-etl
 
 services:
   postgres:
@@ -91,7 +92,7 @@ services:
       retries: 5
     restart: always
     networks:
-      - ideafastetl
+      - ideafast-etl
 
   redis:
     image: redis:latest
@@ -104,7 +105,7 @@ services:
       retries: 50
     restart: always
     networks:
-      - ideafastetl
+      - ideafast-etl
 
   mongodb:
     container_name: mongo
@@ -126,7 +127,7 @@ services:
       start_period: 30s
     restart: always
     networks:
-      - ideafastetl
+      - ideafast-etl
 
   airflow-webserver:
     <<: *airflow-common

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@
 version: '3.5'
 
 networks:
-  ideafastetl:
+  ideafast-etl:
     name: ideafast-etl
     external: true
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,10 @@
 ---
 version: '3.5'
 
+networks:
+  ideafastetl:
+    name: ideafast-etl
+
 x-ideafast-etl-variables:
   &ideafast-etl-env
   AIRFLOW_CONN_MONGO_DEFAULT: 'mongodb://${_MONGO_INITDB_ROOT_USERNAME}:${_MONGO_INITDB_ROOT_PASSWORD}@mongo:27017/%3FauthSource%3Dadmin'
@@ -69,6 +73,8 @@ x-airflow-common:
       condition: service_healthy
     mongodb:
       condition: service_healthy
+  networks:
+    - ideafastetl
 
 services:
   postgres:
@@ -84,6 +90,8 @@ services:
       interval: 5s
       retries: 5
     restart: always
+    networks:
+      - ideafastetl
 
   redis:
     image: redis:latest
@@ -95,6 +103,8 @@ services:
       timeout: 30s
       retries: 50
     restart: always
+    networks:
+      - ideafastetl
 
   mongodb:
     container_name: mongo
@@ -115,6 +125,8 @@ services:
       retries: 5
       start_period: 30s
     restart: always
+    networks:
+      - ideafastetl
 
   airflow-webserver:
     <<: *airflow-common
@@ -305,6 +317,8 @@ services:
       - |
         airflow connections import init/connections.yaml
         airflow variables import init/variables.json
+        airflow users create -e localhost -f local -l host -p '${_WP3API_AIRFLOW_PASS}' -r Viewer -u localhost
+      # FIXME: reconsider local authentication to airflow API
 
   flower:
     <<: *airflow-common


### PR DESCRIPTION
This PR defines an (external) docker network and adds all services to them, such that server-level settings can interact with the containers. 

It also introduces a tiny fix on the CLI with docker versioning.