### PR TITLE
Monitoring pipeline for daily status snapshots and weekly email pipeline updates

### DIFF
--- a/dags/monitoring.py
+++ b/dags/monitoring.py
@@ -1,0 +1,47 @@
+"""DAGs to regularly audit the sensor data ETL process"""
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+with DAG(
+    dag_id="monitoring_weekly_digest",
+    description="Pipeline health monitor weekly email digest",
+    # arbitrary start date, UNLESS USED TO RUN HISTORICALLY!
+    start_date=datetime(year=2021, month=1, day=1),
+    schedule_interval="0 7 * * 1",  # weekly on monday seven in the morning
+    catchup=False,
+    render_template_as_native_obj=True,
+) as dag:
+
+    def _send_report() -> None:
+        """Send email digest to user accounts in the Airflow System"""
+        pass
+
+    # Set all tasks
+    send_report = PythonOperator(
+        task_id="send_report",
+        python_callable=_send_report,
+    )
+
+
+with DAG(
+    dag_id="monitoring_daily",
+    description="Pipeline health monitor daily calculation",
+    # arbitrary start date, UNLESS USED TO RUN HISTORICALLY!
+    start_date=datetime(year=2021, month=1, day=1),
+    schedule_interval="0 6 * * *",  # daily at six in the morning
+    catchup=False,
+    render_template_as_native_obj=True,
+) as dag:
+
+    def _generate_report() -> None:
+        """Audit sensor data DB and Pipeline Health and store report"""
+        pass
+
+    # Set all tasks
+    generate_report = PythonOperator(
+        task_id="generate_report",
+        python_callable=_generate_report,
+    )

--- a/ideafast_etl/hooks/db.py
+++ b/ideafast_etl/hooks/db.py
@@ -229,3 +229,7 @@ class LocalMongoHook(MongoHook):
         """Get all hash representations of stored files"""
         result = self.__custom_find(filter={"device_type": device_type.name})
         return {r.hash for r in result}
+
+    def query_stats(self, query: list) -> List[dict]:
+        """Query the records DB for sensor data progress"""
+        return self.aggregate(**DEFAULTS, aggregate_query=query)

--- a/ideafast_etl/hooks/db_monitoring.py
+++ b/ideafast_etl/hooks/db_monitoring.py
@@ -1,0 +1,82 @@
+import hashlib
+import warnings
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Generator, List, Optional, Set
+
+from airflow.providers.mongo.hooks.mongo import MongoHook
+from bson import ObjectId
+
+from ideafast_etl.hooks.db import DeviceType
+
+DEFAULTS = {"mongo_collection": "etl_monitoring"}
+
+
+@dataclass
+class DeviceMonitorRecord:
+    """Sub ETL stats record for individual pipelines"""
+
+    total_db_records: int
+    not_uploaded: int
+    unique_no_device_id: int = field(init=False)
+    unique_no_patient_id: int = field(init=False)
+    unique_no_dmp_dataset_id: int = field(init=False)
+    unique_not_uploaded: int = field(init=False)
+
+    list_no_device_id: List[str]
+    list_no_patient_id: List[str]
+    list_no_dmp_dataset: List[str]
+    list_not_uploaded: List[str]
+
+    def __post_init__(self):
+        """Calculate and store counts of 'stuck' records"""
+        self.unique_no_device_id = len(self.list_no_device_id)
+        self.unique_no_patient_id = len(self.list_no_patient_id)
+        self.unique_no_dmp_dataset_id = len(self.list_no_dmp_dataset)
+        self.unique_not_uploaded = len(self.list_not_uploaded)
+
+
+@dataclass
+class MonitoringRecord:
+    """1-2-1 mapping of database records, with default initialisers"""
+
+    date: datetime
+    pipeline_stats: Dict[str, DeviceMonitorRecord]
+    _id: Optional[ObjectId] = None
+
+    @property
+    def as_db_dict(self) -> dict:
+        """Convert the dataclass to dict for inserting into MongoDB"""
+        result = asdict(self)
+        result.pop("_id")
+        return result
+
+
+class LocalMonitorMongoHook(MongoHook):
+    """
+    Hook extending MongoHook for interfacing with local MongoDB
+
+    Parameters
+    ----------
+    conn_id : str
+        ID of the connection to use to connect to the Dreem API
+    """
+
+    def custom_insert_one(self, record: MonitoringRecord) -> ObjectId:
+        """Insert one record into the DB, return the ID"""
+        result = self.insert_one(**DEFAULTS, doc=record.as_db_dict)
+        return result.inserted_id
+
+    def get_latest_stats(self) -> Optional[MonitoringRecord]:
+        """Get the latest stats on the metadb"""
+        result = self.find(**DEFAULTS, query={}, find_one=True, sort=[("date", -1)])
+        return MonitoringRecord(**result) if result else None
+
+    def get_stats_by_pipeline(start: datetime, end: datetime):
+        pass
+
+    # def __custom_find(self, filter: dict) -> Generator[Record, None, None]:
+    #     """Get all (full) records with given filter"""
+    #     result = self.find(**DEFAULTS, query=filter)
+    #     yield from (Record(**r) for r in result)


### PR DESCRIPTION
Unfinished, but initial work that tries to implement a daily pipeline that aggregates the metadatabase to form a status overview, and stores this in the same `mongo` metadatabase (in a different collection). Then (uncompleted), a weekly DAG generates an email with the overview of the last week. The daily snapshots keep track of the unique identifiers of data that got 'stuck' in one of the ETL steps, allowing the weekly aggregate to compare and count if any of these were resolved or newly added (rather than just looking at a count). 
For setting up an emailer, look at [this post](https://stackoverflow.com/questions/51829200/how-to-set-up-airflow-send-email) (I'd suggest using the Gmail account we have).